### PR TITLE
Update SparkMeasure_Jupyter_Python_getting_started.ipynb

### DIFF
--- a/examples/SparkMeasure_Jupyter_Python_getting_started.ipynb
+++ b/examples/SparkMeasure_Jupyter_Python_getting_started.ipynb
@@ -60,6 +60,8 @@
     "         .appName(\"Test sparkmeasure instrumentation of Python/PySpark code\")\n",
     "         .master(\"local[*]\")\n",
     "         .config(\"spark.jars.packages\",\"ch.cern.sparkmeasure:spark-measure_2.12:0.24\")\n",
+    "         # Add this line to increase the maximum RPC message size\n",
+    "         .config(\"spark.rpc.message.maxSize\", \"512\") # You can try a larger value if needed, e.g., \"1024m\"\n",
     "         .getOrCreate()\n",
     "        )  \n"
    ]


### PR DESCRIPTION
Add a RPC message size limit to prevent FrameTooLarge errors.